### PR TITLE
Condensed formula bug

### DIFF
--- a/isotope.cabal
+++ b/isotope.cabal
@@ -1,5 +1,5 @@
 name:                isotope
-version:             0.1.2.0
+version:             0.1.3.0
 synopsis:            Isotopic masses and relative abundances.
 description:         Please see README.md
 homepage:            https://github.com/Michaelt293/Element-isotopes/blob/master/README.md

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -683,7 +683,7 @@ newtype CondensedFormula = CondensedFormula {
         deriving (Show, Read, Eq, Ord)
 
 instance ChemicalMass CondensedFormula where
-    toElementalComposition = toElementalComposition
+    toElementalComposition = ElementalComposition . getMolecularFormula . toMolecularFormula
 
 instance ToMolecularFormula CondensedFormula where
     toMolecularFormula c = foldMap foldFunc (getCondensedFormula c)


### PR DESCRIPTION
Important bug fix. A terrible bug had slipped through where the `CondensedFormula` `ChemicalMass` instance was defined as the non terminating function `toElementalComposition = toElementalComposition`.
