### PR TITLE
Use option combinator

### DIFF
--- a/isotope.cabal
+++ b/isotope.cabal
@@ -1,5 +1,5 @@
 name:                isotope
-version:             0.3.1.0
+version:             0.3.2.0
 synopsis:            Isotopic masses and relative abundances.
 description:         Please see README.md
 homepage:            https://github.com/Michaelt293/Element-isotopes/blob/master/README.md

--- a/src/Isotope/Parsers.hs
+++ b/src/Isotope/Parsers.hs
@@ -48,18 +48,12 @@ elementSymbol = read <$> choice (try . string <$> elementSymbolStrList)
 
 -- | Parses an sub-formula (i.e., \"C2\").
 subFormula :: Parser (ElementSymbol, Int)
-subFormula = do
-    sym <- elementSymbol
-    num <- option 1 L.integer
-    return (sym, fromIntegral num)
+subFormula =
+  (\sym num -> (sym, fromIntegral num)) <$> elementSymbol <*> option 1 L.integer
 
 -- | Parses an elemental composition (i.e. \"C6H6\").
 elementalComposition :: Parser ElementalComposition
 elementalComposition = mkElementalComposition <$> many subFormula
-
--- | Parses an sub-molecular-formula (i.e., \"C2\").
-subMolecularFormula :: Parser MolecularFormula
-subMolecularFormula = mkMolecularFormula . pure <$> subFormula
 
 -- | Parses a molecular formula (i.e. \"C6H6\").
 molecularFormula :: Parser MolecularFormula
@@ -69,6 +63,8 @@ molecularFormula = mkMolecularFormula <$> many subFormula
 condensedFormula :: Parser CondensedFormula
 condensedFormula =  CondensedFormula <$> many (leftCondensedFormula <|> rightCondensedFormula)
   where
+    subMolecularFormula :: Parser MolecularFormula
+    subMolecularFormula = mkMolecularFormula . pure <$> subFormula
     leftCondensedFormula :: Parser (Either MolecularFormula (CondensedFormula, Int))
     leftCondensedFormula = Left <$> subMolecularFormula
     rightCondensedFormula :: Parser (Either MolecularFormula (CondensedFormula, Int))

--- a/src/Isotope/Parsers.hs
+++ b/src/Isotope/Parsers.hs
@@ -50,10 +50,8 @@ elementSymbol = read <$> choice (try . string <$> elementSymbolStrList)
 subFormula :: Parser (ElementSymbol, Int)
 subFormula = do
     sym <- elementSymbol
-    num <- optional L.integer
-    return $ case num of
-                  Nothing   -> (sym, 1)
-                  Just num' -> (sym, fromIntegral num')
+    num <- option 1 L.integer
+    return (sym, fromIntegral num)
 
 -- | Parses an elemental composition (i.e. \"C6H6\").
 elementalComposition :: Parser ElementalComposition
@@ -78,10 +76,8 @@ condensedFormula =  CondensedFormula <$> many (leftCondensedFormula <|> rightCon
        _ <- char '('
        formula <- condensedFormula
        _ <- char ')'
-       num <- optional L.integer
-       return . Right $ case num of
-                             Nothing   -> (formula, 1)
-                             Just num' -> (formula, fromIntegral num')
+       num <- option 1 L.integer
+       return $ Right (formula, fromIntegral num)
 
 -- | Parses a empirical formula (i.e. \"CH\").
 empiricalFormula :: Parser EmpiricalFormula


### PR DESCRIPTION
Uses `option` instead of `optional`. This means that pattern matching isn't required.