### PR TITLE
Fixed bug in hill system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ matrix:
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
 
-  - env: BUILD=stack ARGS="--resolver lts-5"
-    compiler: ": #stack 7.10.3"
+  - env: BUILD=stack ARGS="--resolver lts-8"
+    compiler: ": #stack 8.0.2"
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
 
   # Nightly builds are allowed to fail
@@ -53,8 +53,8 @@ matrix:
 
   # Build on OS X in addition to Linux
 
-  - env: BUILD=stack ARGS="--resolver lts-5"
-    compiler: ": #stack 7.10.3 osx"
+  - env: BUILD=stack ARGS="--resolver lts-8"
+    compiler: ": #stack 8.0.2 osx"
     os: osx
 
   - env: BUILD=stack ARGS="--resolver nightly"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ MolecularFormula {getMolecularFormula = fromList [(H,6),(C,3)]}
 
 ### `ToElementalComposition` type class
 
-In addition to the `toElementalComposition` method, the `ToElementalComposition` type class has three other methods; `monoisotopicMass`, `nominalMass` and `averageMass`. (`toElementalComposition` is the minimal complete definition.) `ElementSymbol`, `ElementalComposition`, `MolecularFormula`, `CondensedFormula` and `EmpiricalFormula` all have instances of `ToElementalComposition`. This provides a uniform approach to working with elements, elemental compositions, molecular formulae, condensed formulae and empirical formulae.
+`ToElementalComposition` is a superclass of `ToMolecularFormula`, `ToCondensedFormuala` and `ToEmpiricalFormula`. In addition to the `toElementalComposition` method, the `ToElementalComposition` type class has three other methods; `monoisotopicMass`, `nominalMass` and `averageMass`. (`toElementalComposition` is the minimal complete definition.) `ElementSymbol`, `ElementalComposition`, `MolecularFormula`, `CondensedFormula` and `EmpiricalFormula` all have instances of `ToElementalComposition`. This provides a uniform approach to working with elements, elemental compositions, molecular formulae, condensed formulae and empirical formulae.
 ```haskell
 ghci> nominalMass C
 NominalMass {getNominalMass = 12}

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ MolecularFormula {getMolecularFormula = fromList [(H,6),(C,3)]}
 
 ### `ToElementalComposition` type class
 
-`ToElementalComposition` is a superclass of `ToMolecularFormula`, `ToCondensedFormuala` and `ToEmpiricalFormula`. In addition to the `toElementalComposition` method, the `ToElementalComposition` type class has three other methods; `monoisotopicMass`, `nominalMass` and `averageMass`. (`toElementalComposition` is the minimal complete definition.) `ElementSymbol`, `ElementalComposition`, `MolecularFormula`, `CondensedFormula` and `EmpiricalFormula` all have instances of `ToElementalComposition`. This provides a uniform approach to working with elements, elemental compositions, molecular formulae, condensed formulae and empirical formulae.
+`ToElementalComposition` is a superclass of `ToMolecularFormula`, `ToCondensedFormula` and `ToEmpiricalFormula`. In addition to the `toElementalComposition` method, the `ToElementalComposition` type class has three other methods; `monoisotopicMass`, `nominalMass` and `averageMass`. (`toElementalComposition` is the minimal complete definition.) `ElementSymbol`, `ElementalComposition`, `MolecularFormula`, `CondensedFormula` and `EmpiricalFormula` all have instances of `ToElementalComposition`. This provides a uniform approach to working with elements, elemental compositions, molecular formulae, condensed formulae and empirical formulae.
 ```haskell
 ghci> nominalMass C
 NominalMass {getNominalMass = 12}
@@ -135,7 +135,7 @@ Monoid instances are also provide for `ElementalComposition`, `MonoisotopicMass`
 
 #### Laws for `ElementalComposition`, `MolecularFormula`, `EmpiricalFormula` and `CondensedFormula` data types
 
-Instances of `ToElementalComposition`, `ToMolecularFormula`, `ToCondensedFormuala` and `ToEmpiricalFormula` should abide by three laws. 1) Applying `toEmpiricalFormula` to a `CondensedFormula` should give the same result as applying `toMolecularFormula` compose `toEmpiricalFormula`.
+Instances of `ToElementalComposition`, `ToMolecularFormula`, `ToCondensedFormula` and `ToEmpiricalFormula` should abide by three laws. 1) Applying `toEmpiricalFormula` to a `CondensedFormula` should give the same result as applying `toMolecularFormula` compose `toEmpiricalFormula`.
 2) Applying `toElementalComposition` to a `CondensedFormula` should give the same result as applying `toMolecularFormula` compose `toElementalComposition`.
 3) Applying `toElementalComposition . toEmpiricalFormula` to an `EmpiricalFormula` should return the same `EmpiricalFormula`.
 

--- a/isotope.cabal
+++ b/isotope.cabal
@@ -20,7 +20,6 @@ library
                      , Isotope.Parsers
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5 && < 0.6
-                     , mtl
                      , megaparsec >= 5 && < 6
                      , template-haskell
                      , th-lift
@@ -35,7 +34,7 @@ test-suite Element-isotopes-test
                      , isotope
                      , hspec
                      , QuickCheck
-                     , megaparsec >= 5 && < 6
+                     , megaparsec
   other-modules:       Isotope.BaseSpec
                      , Isotope.ParsersSpec
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/isotope.cabal
+++ b/isotope.cabal
@@ -35,7 +35,7 @@ test-suite Element-isotopes-test
                      , isotope
                      , hspec
                      , QuickCheck
-                     , megaparsec >= 4 && < 6
+                     , megaparsec >= 5 && < 6
   other-modules:       Isotope.BaseSpec
                      , Isotope.ParsersSpec
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/isotope.cabal
+++ b/isotope.cabal
@@ -1,5 +1,5 @@
 name:                isotope
-version:             0.3.3.0
+version:             0.4.0.0
 synopsis:            Isotopic masses and relative abundances.
 description:         Please see README.md
 homepage:            https://github.com/Michaelt293/Element-isotopes/blob/master/README.md

--- a/isotope.cabal
+++ b/isotope.cabal
@@ -20,7 +20,8 @@ library
                      , Isotope.Parsers
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5 && < 0.6
-                     , megaparsec >= 4 && < 6
+                     , mtl
+                     , megaparsec >= 5 && < 6
                      , template-haskell
                      , th-lift
   default-language:    Haskell2010

--- a/src/Isotope.hs
+++ b/src/Isotope.hs
@@ -68,7 +68,7 @@ module Isotope (
   , mkMolecularFormula
   -- * Condensed formulae
   , CondensedFormula(..)
-  , ToCondensedFormuala(..)
+  , ToCondensedFormula(..)
   -- * Empirical formulae
   , EmpiricalFormula(..)
   , ToEmpiricalFormula(..)

--- a/src/Isotope.hs
+++ b/src/Isotope.hs
@@ -47,7 +47,6 @@ module Isotope (
   -- * 'elements' - a map containing isotopic data for each element.
   , elements
   -- * Functions taking an 'elementSymbol' as input
-  , lookupElement
   , findElement
   , elementName
   , atomicNumber

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -1,7 +1,7 @@
 {-|
 Module      : Isotope.Base
-Description : Contains most of the data type declarations used in the Isotope
-              library.
+Description : Contains the data type and type class declarations used in the
+              Isotope library.
 Copyright   : Michael Thomas
 License     : GPL-3
 Maintainer  : Michael Thomas <Michaelt293@gmail.com>
@@ -68,33 +68,24 @@ module Isotope.Base (
     , ElementalComposition(..)
     , ToElementalComposition(..)
     , mkElementalComposition
-    -- Molecular formulae
+    -- Molecular formula
     , MolecularFormula(..)
     , ToMolecularFormula(..)
     , mkMolecularFormula
-    -- Condensed formulae
+    -- Condensed formula
     , CondensedFormula(..)
-    , ToCondensedFormuala(..)
+    , ToCondensedFormula(..)
     -- Empirical formula
     , EmpiricalFormula(..)
     , ToEmpiricalFormula(..)
     , mkEmpiricalFormula
     ) where
 
-import Prelude hiding      (lookup,filter)
-import Data.Map            ( Map
-                           , fromList
-                           , unionWith
-                           , filter
-                           , mapWithKey
-                           , lookup
-                           , (!)
-                           , toList
-                           )
-import Data.Foldable hiding (toList)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Foldable
 import Data.Ord
-import Data.List           (elemIndex, sortBy)
-import Data.Maybe          (fromJust)
+import Data.List
 import Data.Monoid
 
 --------------------------------------------------------------------------------
@@ -117,7 +108,7 @@ type IntegerMass = MassNumber
 
 -- | The exact mass of the most abundant isotope for an element or the sum of
 -- the exact masses of the most abundant isotope of each element for a
--- molecular formula.
+-- elemental composition.
 newtype MonoisotopicMass = MonoisotopicMass { getMonoisotopicMass :: Double }
                          deriving (Show, Eq, Ord)
 
@@ -131,8 +122,8 @@ instance Operators MonoisotopicMass where
   MonoisotopicMass x |*| y = MonoisotopicMass $ x * fromIntegral y
 
 -- | The integer mass of the most abundant isotope for an element or the sum of
--- integer mass of the most abundant isotope of each element for a chemical
--- formula.
+-- integer mass of the most abundant isotope of each element for a elemental
+-- composition.
 newtype NominalMass = NominalMass { getNominalMass :: Int }
                     deriving (Show, Eq, Ord)
 
@@ -145,7 +136,7 @@ instance Operators NominalMass where
   NominalMass x |-| NominalMass y = NominalMass $ x - y
   NominalMass x |*| y = NominalMass $ x * y
 
--- | The average mass of an element or molecular formula based on
+-- | The average mass of an element or elemental composition based on
 -- naturally-occurring abundances.
 newtype AverageMass = AverageMass { getAverageMass :: Double }
                     deriving (Show, Eq, Ord)
@@ -283,14 +274,15 @@ tupleToIsotope :: (Nucleons, Double, Double) -> Isotope
 tupleToIsotope (nucl, mass, abun) =
   Isotope nucl (IsotopicMass mass) (IsotopicAbundance abun)
 
-tupleToElement :: (AtomicNumber, ElementName, [(Nucleons, Double, Double)]) -> Element
+tupleToElement
+  :: (AtomicNumber, ElementName, [(Nucleons, Double, Double)]) -> Element
 tupleToElement (atomNum, name, isotopes) =
   Element atomNum name (tupleToIsotope <$> isotopes)
 
 -- | Map of the periodic table. All data on isotopic masses and abundances is
 -- contained within this map.
 elements :: Map ElementSymbol Element
-elements = tupleToElement <$> fromList
+elements = tupleToElement <$> Map.fromList
   [ (H,  (1, "hydrogen",      [ ((1, 0),     1.00782503223,  0.999885)
                               , ((1, 1),     2.01410177812,  0.000115) ]))
   , (He, (2,  "helium",       [ ((2, 1),     3.0160293201,   0.00000134)
@@ -587,7 +579,7 @@ elements = tupleToElement <$> fromList
 -- | Searches 'elements' (a map) with an 'ElementSymbol' key and returns
 -- information for the element.
 findElement :: ElementSymbol -> Element
-findElement = (!) elements
+findElement = (Map.!) elements
 
 -- | Returns the name for an element symbol.
 elementName :: ElementSymbol -> ElementName
@@ -606,11 +598,11 @@ mostAbundantIsotope :: ElementSymbol -> Isotope
 mostAbundantIsotope = elementMostAbundantIsotope . findElement
 
 -- | Selects an isotope of element based on the isotope's mass number
--- ('IntegerMass'). Note: This is a partial function.
-selectIsotope :: ElementSymbol -> MassNumber -> Isotope
-selectIsotope sym mass = isotopeList !! indexOfIsotope
+-- ('IntegerMass').
+selectIsotope :: ElementSymbol -> MassNumber -> Maybe Isotope
+selectIsotope sym massNum =
+  find (\iso -> (massNumber . nucleons) iso ==  massNum) isotopeList
     where isotopeList = isotopes sym
-          indexOfIsotope = fromJust $ elemIndex mass (integerMasses sym)
 
 -- | Exact masses for all naturally-occurring isotopes for an element.
 isotopicMasses :: ElementSymbol -> [IsotopicMass]
@@ -627,7 +619,7 @@ isotopicAbundances = elementIsotopicAbundances . findElement
 --------------------------------------------------------------------------------
 -- Formula type class
 
--- | Type class with two methods, 'renderFormula' and 'emptyFormula'. The
+-- | Type class with two methods; 'renderFormula' and 'emptyFormula'. The
 -- 'renderFormula' method converts a formula to its shorthand notation.
 class Formula a where
     renderFormula :: a -> String
@@ -659,12 +651,12 @@ class ToElementalComposition a where
 getFormulaSum :: (Monoid a, Operators a, ToElementalComposition b)
   => (Element -> a) -> b -> a
 getFormulaSum f m = fold $
-    mapWithKey mapFunc (getElementalComposition (toElementalComposition m))
+    Map.mapWithKey mapFunc (getElementalComposition (toElementalComposition m))
   where mapFunc k v = (f . findElement) k |*| v
 
 -- | Smart constructor to make values of type 'ElementalComposition'.
 mkElementalComposition :: [(ElementSymbol, Int)] -> ElementalComposition
-mkElementalComposition = ElementalComposition . filterZero . fromList
+mkElementalComposition = ElementalComposition . filterZero . Map.fromList
 
 instance Monoid ElementalComposition where
   mempty = emptyFormula
@@ -700,7 +692,7 @@ renderFoldfunc (sym, num) = show sym <> if num == 1
 sortElementSymbolMap :: Map ElementSymbol Int -> [(ElementSymbol, Int)]
 sortElementSymbolMap m = sortBy (hillSystem fst) elementSymbolIntList
     where
-      elementSymbolIntList = toList m
+      elementSymbolIntList = Map.toList m
       elementSymbols = fst <$> elementSymbolIntList
       containsC = C `elem` elementSymbols
       hillSystem f a b = case (f a, f b) of
@@ -726,15 +718,15 @@ class ToElementalComposition a => ToMolecularFormula a where
 -- The function unionWith adapted to work with 'Map ElementSymbol Int'.
 combineMaps :: (Int -> Int -> Int)
   -> Map ElementSymbol Int ->  Map ElementSymbol Int  ->  Map ElementSymbol Int
-combineMaps f m1 m2 = filterZero $ unionWith f m1 m2
+combineMaps f m1 m2 = filterZero $ Map.unionWith f m1 m2
 
 -- | Smart constructor to make values of type 'MolecularFormula'.
 mkMolecularFormula :: [(ElementSymbol, Int)] -> MolecularFormula
-mkMolecularFormula = MolecularFormula . filterZero . fromList
+mkMolecularFormula = MolecularFormula . filterZero . Map.fromList
 
 -- Helper function to remove (k, v) pairs where v == 0.
 filterZero :: Map k Int -> Map k Int
-filterZero = filter (/= 0)
+filterZero = Map.filter (/= 0)
 
 instance Monoid MolecularFormula where
    mempty = emptyFormula
@@ -764,7 +756,7 @@ newtype CondensedFormula = CondensedFormula {
     getCondensedFormula :: [Either MolecularFormula (CondensedFormula, Int)] }
         deriving (Show, Read, Eq, Ord)
 
-class ToElementalComposition a => ToCondensedFormuala a where
+class ToElementalComposition a => ToCondensedFormula a where
   toCondensedFormula :: a -> CondensedFormula
 
 instance Monoid CondensedFormula where
@@ -798,7 +790,7 @@ newtype EmpiricalFormula = EmpiricalFormula {
     getEmpiricalFormula :: Map ElementSymbol Int }
         deriving (Show, Read, Eq, Ord)
 
--- | Type class with a single method, 'toEmpiricalFormula', which converts a
+-- | Type class with a single method; 'toEmpiricalFormula', which converts a
 -- chemical data type to `EmpiricalFormula`.
 class ToElementalComposition a => ToEmpiricalFormula a where
   toEmpiricalFormula :: a -> EmpiricalFormula
@@ -806,7 +798,7 @@ class ToElementalComposition a => ToEmpiricalFormula a where
 -- | Smart constructor to make values of type 'EmpiricalFormula'.
 mkEmpiricalFormula :: [(ElementSymbol, Int)] -> EmpiricalFormula
 mkEmpiricalFormula l =
-  let m = filterZero (fromList l)
+  let m = filterZero (Map.fromList l)
   in EmpiricalFormula $ (`div` greatestCommonDenom m) <$> m
 
 instance ToEmpiricalFormula ElementalComposition where

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -53,7 +53,6 @@ module Isotope.Base (
     -- 'elements' - a map containing isotopic data for each element.
     , elements
     -- Functions taking an 'elementSymbol' as input
-    , lookupElement
     , findElement
     , elementName
     , atomicNumber
@@ -584,11 +583,6 @@ elements = tupleToElement <$> fromList
 
 --------------------------------------------------------------------------------
 -- Functions taking an 'elementSymbol' as input
-
--- | Searches elements (a map) with an 'ElementSymbol' key and returns
--- information for the element (wrapped in 'Maybe').
-lookupElement :: ElementSymbol -> Maybe Element
-lookupElement = flip lookup elements
 
 -- | Searches 'elements' (a map) with an 'ElementSymbol' key and returns
 -- information for the element.

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -713,9 +713,9 @@ sortElementSymbolMap m = sortBy (hillSystem fst) elementSymbolIntList
         (C, _)   -> LT
         (_, C)   -> GT
         (H, b')  -> if containsC then LT
-                    else (show . elementName) H `compare` show b'
+                    else show H `compare` show b'
         (a', H)  -> if containsC then GT
-                    else show a' `compare` (show . elementName) H
+                    else show a' `compare` show H
         (a', b') -> show a' `compare` show b'
 
 --------------------------------------------------------------------------------

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -726,7 +726,7 @@ newtype MolecularFormula = MolecularFormula {
     getMolecularFormula :: Map ElementSymbol Int }
         deriving (Show, Read, Eq, Ord)
 
-class ToMolecularFormula a where
+class ToElementalComposition a => ToMolecularFormula a where
     toMolecularFormula :: a -> MolecularFormula
 
 -- The function unionWith adapted to work with 'Map ElementSymbol Int'.
@@ -770,7 +770,7 @@ newtype CondensedFormula = CondensedFormula {
     getCondensedFormula :: [Either MolecularFormula (CondensedFormula, Int)] }
         deriving (Show, Read, Eq, Ord)
 
-class ToCondensedFormuala a where
+class ToElementalComposition a => ToCondensedFormuala a where
   toCondensedFormula :: a -> CondensedFormula
 
 instance Monoid CondensedFormula where
@@ -806,7 +806,7 @@ newtype EmpiricalFormula = EmpiricalFormula {
 
 -- | Type class with a single method, 'toEmpiricalFormula', which converts a
 -- chemical data type to `EmpiricalFormula`.
-class ToEmpiricalFormula a where
+class ToElementalComposition a => ToEmpiricalFormula a where
   toEmpiricalFormula :: a -> EmpiricalFormula
 
 -- | Smart constructor to make values of type 'EmpiricalFormula'.

--- a/src/Isotope/Parsers.hs
+++ b/src/Isotope/Parsers.hs
@@ -31,12 +31,10 @@ import Isotope.Base
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Lift
-import Control.Monad.Except (throwError)
 import Text.Megaparsec
 import Text.Megaparsec.String
 import qualified Text.Megaparsec.Lexer as L
-import Data.String
-import Data.List hiding (filter)
+import Data.List
 import Data.Map (Map)
 import Data.Monoid ((<>))
 
@@ -125,7 +123,7 @@ ele = QuasiQuoter {
 -- | Quasiquoter for `MolecularFormula`
 mol :: QuasiQuoter
 mol = QuasiQuoter {
-  quoteExp = quoteMolecularFormula
+    quoteExp = quoteMolecularFormula
   , quotePat  = notHandled "patterns" "molecular formula"
   , quoteType = notHandled "types" "molecular formula"
   , quoteDec  = notHandled "declarations" "molecular formula"
@@ -134,7 +132,7 @@ mol = QuasiQuoter {
 -- | Quasiquoter for `CondensedFormula`
 con :: QuasiQuoter
 con = QuasiQuoter {
-quoteExp = quoteCondensedFormula
+    quoteExp = quoteCondensedFormula
   , quotePat  = notHandled "patterns" "condensed formula"
   , quoteType = notHandled "types" "condensed formula"
   , quoteDec  = notHandled "declarations" "condensed formula"
@@ -142,7 +140,8 @@ quoteExp = quoteCondensedFormula
 
 -- | Quasiquoter for `EmpiricalFormula`
 emp :: QuasiQuoter
-emp = QuasiQuoter{ quoteExp = quoteEmpiricalFormula
+emp = QuasiQuoter {
+    quoteExp = quoteEmpiricalFormula
   , quotePat  = notHandled "patterns" "empirical formula"
   , quoteType = notHandled "types" "empirical formula"
   , quoteDec  = notHandled "declarations" "empirical formula"

--- a/src/Isotope/Parsers.hs
+++ b/src/Isotope/Parsers.hs
@@ -31,6 +31,7 @@ import Isotope.Base
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Lift
+import Control.Monad.Except (throwError)
 import Text.Megaparsec
 import Text.Megaparsec.String
 import qualified Text.Megaparsec.Lexer as L
@@ -85,27 +86,31 @@ empiricalFormula = mkEmpiricalFormula <$> many subFormula
 quoteElementalComposition :: String -> Q Exp
 quoteElementalComposition s =
   case parse (condensedFormula <* eof) "" s of
-    Left err -> error $ "Could not parse formula: " <> show err
+    Left err -> fail $
+      "Could not parse elemental formula!\n" <> parseErrorPretty err
     Right v  -> lift $ toElementalComposition v
 
 -- Helper function for `MolecularFormula` quasiquoter
 quoteMolecularFormula :: String -> Q Exp
 quoteMolecularFormula s =
   case parse (condensedFormula <* eof) "" s of
-    Left err -> fail $ "Could not parse formula: " <> show err
+    Left err -> fail $
+      "Could not parse molecular formula!\n" <> parseErrorPretty err
     Right v  -> lift $ toMolecularFormula v
 
 -- Helper function for `CondensedFormula` quasiquoter
 quoteCondensedFormula :: String -> Q Exp
 quoteCondensedFormula s =
   case parse (condensedFormula <* eof) "" s of
-    Left err -> error $ "Could not parse formula: " <> show err
+    Left err -> fail $
+      "Could not parse condensed formula!\n" <> parseErrorPretty err
     Right v  -> lift v
 
 -- Helper function for `EmpiricalFormula` quasiquoter
 quoteEmpiricalFormula s =
   case parse (condensedFormula <* eof) "" s of
-    Left err -> fail $ "Could not parse formula: " <> show err
+    Left err -> fail $
+      "Could not parse empirical formula!\n" <> parseErrorPretty err
     Right v  -> lift $ toEmpiricalFormula v
 
 -- | Quasiquoter for `ElementalComposition`

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-8.2
+resolver: lts-8.4
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/test/Isotope/BaseSpec.hs
+++ b/test/Isotope/BaseSpec.hs
@@ -18,9 +18,9 @@ spec = do
         (\x -> length x /= 2 || (isLower . last) x) . show <$>
         elementSymbolList `shouldSatisfy` and
 
-    describe "lookupElement" .
+    describe "elementSymbolList" .
       it "should not contain duplicate elements" $
-        lookupElement <$> elementSymbolList `shouldSatisfy` allUnique
+        findElement <$> elementSymbolList `shouldSatisfy` allUnique
 
     describe "elementName" $ do
       it "should not be an empty string" $

--- a/test/Isotope/BaseSpec.hs
+++ b/test/Isotope/BaseSpec.hs
@@ -47,7 +47,7 @@ spec = do
 
     describe "selectIsotope" .
       it "calling fuction with the arguments C and 12 should select C12" $
-        nucleons (selectIsotope C 12) `shouldBe` (6, 6)
+        nucleons <$> selectIsotope C 12 `shouldBe` Just (6, 6)
 
     describe "monoisotopicMass" .
       it "calling function with C should be 12.0" $

--- a/test/Isotope/BaseSpec.hs
+++ b/test/Isotope/BaseSpec.hs
@@ -93,6 +93,8 @@ spec = do
         renderFormula [mol|CCl4|] `shouldBe` "CCl4"
       it "[mol|H2O4S|] should be \"H2O4S\"" $
         renderFormula [mol|H2O4S|] `shouldBe` "H2O4S"
+      it "[mol|BBr3|] should be \"BBr3\"" $
+        renderFormula [mol|BBr3|] `shouldBe` "BBr3"
 
     describe "renderFormula for CondensedFormula" $ do
       it "[con|C6H6O|] should be \"C6H6O\"" $


### PR DESCRIPTION
From Wikipeda -

> The Hill system (or Hill notation) is a system of writing empirical chemical formulas, molecular chemical formulas and components of a condensed formula such that the number of carbon atoms in a molecule is indicated first, the number of hydrogen atoms next, and then the number of all other chemical elements subsequently, in alphabetical order of the chemical symbols. When the formula contains no carbon, all the elements, including hydrogen, are listed alphabetically.

> .... single-letter elements coming before two-letter symbols when the symbols begin with the same letter (so "B" comes before "Be", which comes before "Br").

The bug involved using the element name for Hydrogen instead of the element symbol.