### PR TITLE
Introduced better errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,6 @@ matrix:
 
   # Build on OS X in addition to Linux
 
-  - env: BUILD=stack ARGS="--resolver lts-8"
-    compiler: ": #stack 8.0.2 osx"
-    os: osx
-
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly osx"
     os: osx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 * Added `Ion` module.
 * Added `charge` method to `ToElementalComposition` type class.
 * Added `Charge` type alias.
+
+### 0.5.1.0
+
+* Previously, Isotope was using string-based error messages for `mz` and `polarity` methods. A custom exception type, `IonHasChargeZero`, is introduced to replace these string-based errors.

--- a/isotope.cabal
+++ b/isotope.cabal
@@ -1,5 +1,5 @@
 name:                isotope
-version:             0.5.0.1
+version:             0.5.1.0
 synopsis:            Isotopic masses and relative abundances.
 description:         Please see README.md
 homepage:            https://github.com/Michaelt293/Element-isotopes/blob/master/README.md
@@ -22,6 +22,7 @@ library
   build-depends:       base >= 4.7 && < 5
                      , containers >= 0.5 && < 0.6
                      , megaparsec >= 5 && < 6
+                     , safe-exceptions > 0.1 && < 0.2
                      , template-haskell
                      , th-lift
   default-language:    Haskell2010

--- a/src/Isotope/Base.hs
+++ b/src/Isotope/Base.hs
@@ -624,8 +624,8 @@ isotopicAbundances = elementIsotopicAbundances . findElement
 -- | Type class with two methods; 'renderFormula' and 'emptyFormula'. The
 -- 'renderFormula' method converts a formula to its shorthand notation.
 class Formula a where
-    renderFormula :: a -> String
-    emptyFormula  :: a
+  renderFormula :: a -> String
+  emptyFormula  :: a
 
 --------------------------------------------------------------------------------
 -- Elemental composition
@@ -633,21 +633,21 @@ class Formula a where
 -- | Provided since 'EmpiricalFormula' can be thought of as an elemenal
 -- composition but is not a molecular formula.
 newtype ElementalComposition = ElementalComposition  {
-    getElementalComposition :: Map ElementSymbol Int }
-        deriving (Show, Read, Eq, Ord)
+  getElementalComposition :: Map ElementSymbol Int }
+    deriving (Show, Read, Eq, Ord)
 
 -- | Class containing four methods; 'toElementalComposition',
 -- 'monoisotopicMass', 'nominalMass' and 'averageMass'.
 class ToElementalComposition a where
-     toElementalComposition :: a -> ElementalComposition
-     charge                 :: a -> Maybe Charge
-     monoisotopicMass       :: a -> MonoisotopicMass
-     nominalMass            :: a -> NominalMass
-     averageMass            :: a -> AverageMass
-     monoisotopicMass = getFormulaSum elementMonoisotopicMass
-     nominalMass      = getFormulaSum elementNominalMass
-     averageMass      = getFormulaSum elementAverageMass
-     {-# MINIMAL (toElementalComposition, charge) #-}
+  toElementalComposition :: a -> ElementalComposition
+  charge                 :: a -> Maybe Charge
+  monoisotopicMass       :: a -> MonoisotopicMass
+  nominalMass            :: a -> NominalMass
+  averageMass            :: a -> AverageMass
+  monoisotopicMass = getFormulaSum elementMonoisotopicMass
+  nominalMass      = getFormulaSum elementNominalMass
+  averageMass      = getFormulaSum elementAverageMass
+  {-# MINIMAL (toElementalComposition, charge) #-}
 
 -- Helper function for the calculating monoistopic masses, average mass and
 -- nominal masses for molecular formulae.
@@ -674,17 +674,17 @@ instance Operators ElementalComposition where
               (fromIntegral n *) <$> getElementalComposition m
 
 instance ToElementalComposition ElementSymbol where
-    toElementalComposition sym = mkElementalComposition [(sym, 1)]
-    charge _ = Nothing
+  toElementalComposition sym = mkElementalComposition [(sym, 1)]
+  charge _ = Nothing
 
 instance ToElementalComposition ElementalComposition where
   toElementalComposition = id
   charge _ = Nothing
 
 instance Formula ElementalComposition where
-   renderFormula f = foldMap renderFoldfunc
-                     ((sortElementSymbolMap . getElementalComposition) f)
-   emptyFormula    = mkElementalComposition []
+  renderFormula f = foldMap renderFoldfunc
+                    ((sortElementSymbolMap . getElementalComposition) f)
+  emptyFormula    = mkElementalComposition []
 
 -- Helper function for 'renderFormula'.
 renderFoldfunc :: (ElementSymbol, Int) -> String
@@ -696,29 +696,29 @@ renderFoldfunc (sym, num) = show sym <> if num == 1
 -- alphabetical order.
 sortElementSymbolMap :: Map ElementSymbol Int -> [(ElementSymbol, Int)]
 sortElementSymbolMap m = sortBy (hillSystem fst) elementSymbolIntList
-    where
-      elementSymbolIntList = Map.toList m
-      elementSymbols = fst <$> elementSymbolIntList
-      containsC = C `elem` elementSymbols
-      hillSystem f a b = case (f a, f b) of
-        (C, _)   -> LT
-        (_, C)   -> GT
-        (H, b')  -> if containsC then LT
-                    else show H `compare` show b'
-        (a', H)  -> if containsC then GT
-                    else show a' `compare` show H
-        (a', b') -> show a' `compare` show b'
+  where
+    elementSymbolIntList = Map.toList m
+    elementSymbols = fst <$> elementSymbolIntList
+    containsC = C `elem` elementSymbols
+    hillSystem f a b = case (f a, f b) of
+      (C, _)   -> LT
+      (_, C)   -> GT
+      (H, b')  -> if containsC then LT
+                  else show H `compare` show b'
+      (a', H)  -> if containsC then GT
+                  else show a' `compare` show H
+      (a', b') -> show a' `compare` show b'
 
 --------------------------------------------------------------------------------
 -- Molecular formulae
 
 -- | 'MolecularFormula' is a newtype to represent a molecular formula.
 newtype MolecularFormula = MolecularFormula {
-    getMolecularFormula :: Map ElementSymbol Int }
-        deriving (Show, Read, Eq, Ord)
+  getMolecularFormula :: Map ElementSymbol Int }
+    deriving (Show, Read, Eq, Ord)
 
 class ToElementalComposition a => ToMolecularFormula a where
-    toMolecularFormula :: a -> MolecularFormula
+  toMolecularFormula :: a -> MolecularFormula
 
 -- The function unionWith adapted to work with 'Map ElementSymbol Int'.
 combineMaps :: (Int -> Int -> Int)
@@ -734,8 +734,8 @@ filterZero :: Map k Int -> Map k Int
 filterZero = Map.filter (/= 0)
 
 instance Monoid MolecularFormula where
-   mempty = emptyFormula
-   mappend = (|+|)
+  mempty = emptyFormula
+  mappend = (|+|)
 
 instance Operators MolecularFormula where
   MolecularFormula x |+| MolecularFormula y =
@@ -746,21 +746,21 @@ instance Operators MolecularFormula where
               (fromIntegral n *) <$> getMolecularFormula m
 
 instance ToElementalComposition MolecularFormula where
-    toElementalComposition (MolecularFormula m) = ElementalComposition m
-    charge _ = Nothing
+  toElementalComposition (MolecularFormula m) = ElementalComposition m
+  charge _ = Nothing
 
 instance Formula MolecularFormula where
-   renderFormula f = foldMap renderFoldfunc
-                     ((sortElementSymbolMap . getMolecularFormula) f)
-   emptyFormula = mkMolecularFormula []
+  renderFormula f = foldMap renderFoldfunc
+                  ((sortElementSymbolMap . getMolecularFormula) f)
+  emptyFormula = mkMolecularFormula []
 
 --------------------------------------------------------------------------------
 -- Condensed formulae
 
 -- | 'CondensedFormula' is a newtype to represent a condensed formula.
 newtype CondensedFormula = CondensedFormula {
-    getCondensedFormula :: [Either MolecularFormula (CondensedFormula, Int)] }
-        deriving (Show, Read, Eq, Ord)
+  getCondensedFormula :: [Either MolecularFormula (CondensedFormula, Int)] }
+    deriving (Show, Read, Eq, Ord)
 
 class ToElementalComposition a => ToCondensedFormula a where
   toCondensedFormula :: a -> CondensedFormula
@@ -770,32 +770,32 @@ instance Monoid CondensedFormula where
   CondensedFormula x `mappend` CondensedFormula y = CondensedFormula (x <> y)
 
 instance ToElementalComposition CondensedFormula where
-    toElementalComposition =
-      ElementalComposition . getMolecularFormula . toMolecularFormula
-    charge _ = Nothing
+  toElementalComposition =
+    ElementalComposition . getMolecularFormula . toMolecularFormula
+  charge _ = Nothing
 
 instance ToMolecularFormula CondensedFormula where
-    toMolecularFormula c = foldMap foldFunc (getCondensedFormula c)
-       where foldFunc = \case
-                         Left chemForm -> chemForm
-                         Right (condForm, n) -> toMolecularFormula condForm |*| n
+  toMolecularFormula c = foldMap foldFunc (getCondensedFormula c)
+    where foldFunc = \case
+                      Left chemForm -> chemForm
+                      Right (condForm, n) -> toMolecularFormula condForm |*| n
 
 instance Formula CondensedFormula where
-    renderFormula c = foldMap foldFunc (getCondensedFormula c)
-        where foldFunc = \case
-                          Left chemForm -> renderFormula chemForm
-                          Right (chemFormList, n) ->
-                            "(" <> renderFormula chemFormList <> ")"
-                             <> formatNum n
-                                where formatNum n' = if n' == 1 then ""
-                                                     else show n'
-    emptyFormula = CondensedFormula []
+  renderFormula c = foldMap foldFunc (getCondensedFormula c)
+    where foldFunc = \case
+                      Left chemForm -> renderFormula chemForm
+                      Right (chemFormList, n) ->
+                        "(" <> renderFormula chemFormList <> ")"
+                         <> formatNum n
+                            where formatNum n' = if n' == 1 then ""
+                                                 else show n'
+  emptyFormula = CondensedFormula []
 
 --------------------------------------------------------------------------------
 -- | 'EmpiricalFormula' is a newtype to represent a empirical formula.
 newtype EmpiricalFormula = EmpiricalFormula {
-    getEmpiricalFormula :: Map ElementSymbol Int }
-        deriving (Show, Read, Eq, Ord)
+  getEmpiricalFormula :: Map ElementSymbol Int }
+    deriving (Show, Read, Eq, Ord)
 
 -- | Type class with a single method; 'toEmpiricalFormula', which converts a
 -- chemical data type to `EmpiricalFormula`.
@@ -824,9 +824,9 @@ instance ToElementalComposition EmpiricalFormula where
   charge _ = Nothing
 
 instance Formula EmpiricalFormula where
-   renderFormula f = foldMap renderFoldfunc
-                     ((sortElementSymbolMap . getEmpiricalFormula) f)
-   emptyFormula = mkEmpiricalFormula []
+  renderFormula f = foldMap renderFoldfunc
+                    ((sortElementSymbolMap . getEmpiricalFormula) f)
+  emptyFormula = mkEmpiricalFormula []
 
 -- Helper function to find the greatest common denominator in a map.
 greatestCommonDenom :: (Integral v) => Map k v -> v

--- a/src/Isotope/Ion.hs
+++ b/src/Isotope/Ion.hs
@@ -46,8 +46,8 @@ class ToElementalComposition a => Ion a where
 data IonHasChargeZero = IonHasChargeZero deriving (Eq, Typeable)
 
 instance Show IonHasChargeZero where
-  show _ = "Ion cannot have charge of 0"
-  
+  show _ = "Ion has charge of 0"
+
 instance Exception IonHasChargeZero
 
 -- | Protonated represents a protonated ion.

--- a/test/Isotope/IonSpec.hs
+++ b/test/Isotope/IonSpec.hs
@@ -8,15 +8,15 @@ spec :: Spec
 spec = do
   describe "mz" $ do
     it "The mass-to-charge ratio of protonated water should be 19.01838971626" $
-      mz (Protonated water) `shouldBe` Mz {getMz = 19.01838971626}
+      mz (Protonated water) >>= (`shouldBe` Mz {getMz = 19.01838971626})
     it "The mass-to-charge ratio of deprotonated water should be 17.0027396518" $
-      mz (Deprotonated water) `shouldBe` Mz {getMz = 17.0027396518}
+      mz (Deprotonated water) >>= (`shouldBe` Mz {getMz = 17.0027396518})
 
   describe "polarity" $ do
     it "The polarity of protonated water should be Positive" $
-      polarity (Protonated water) `shouldBe` Positive
+      polarity (Protonated water) >>= (`shouldBe` Positive)
     it "The polarity of deprotonated water should be Negative" $
-      polarity (Deprotonated water) `shouldBe` Negative
+      polarity (Deprotonated water) >>= (`shouldBe` Negative)
 
 water :: MolecularFormula
 water = mkMolecularFormula [(H, 2), (O, 1)]


### PR DESCRIPTION
Previously, Isotope was using string-based error messages for `mz` and `polarity` methods. This pull request introduces a custom exception type, `IonHasChargeZero`. (Ideally, this would be a compile-time error - this is left as a task to do.)